### PR TITLE
add Carbon framework to fix a building error in VVDocumenterTests

### DIFF
--- a/VVDocumenter-Xcode.xcodeproj/project.pbxproj
+++ b/VVDocumenter-Xcode.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		53C67935184501030030C553 /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 893D8F7F18262EF500E8A00C /* Carbon.framework */; };
 		893D8F8018262EF500E8A00C /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 893D8F7F18262EF500E8A00C /* Carbon.framework */; };
 		D114BEE0179644D00043FA65 /* NSString+PDRegex.m in Sources */ = {isa = PBXBuildFile; fileRef = D114BEDE179644D00043FA65 /* NSString+PDRegex.m */; };
 		D114BEE3179644FA0043FA65 /* NSTextView+VVTextGetter.m in Sources */ = {isa = PBXBuildFile; fileRef = D114BEE2179644FA0043FA65 /* NSTextView+VVTextGetter.m */; };
@@ -117,6 +118,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				53C67935184501030030C553 /* Carbon.framework in Frameworks */,
 				D1C462DC17999C2000EB7B23 /* SenTestingKit.framework in Frameworks */,
 				D1C462DD17999C2000EB7B23 /* Cocoa.framework in Frameworks */,
 			);


### PR DESCRIPTION
It seems Carbon.framework should be added to VVDocumenterTests.
