### PR TITLE
Added an option to avoid aligning argument comments

### DIFF
--- a/VVDocumenter-Xcode/Commenter/VVBaseCommenter.m
+++ b/VVDocumenter-Xcode/Commenter/VVBaseCommenter.m
@@ -50,9 +50,13 @@
     int longestNameLength = [[self.arguments valueForKeyPath:@"@max.name.length"] intValue];
 
     for (VVArgument *arg in self.arguments) {
-        NSString *paddedName = [arg.name stringByPaddingToLength:longestNameLength withString:@" " startingAtIndex:0];
+        NSString *name = arg.name;
 
-        [result appendFormat:@"%@@param %@ <#%@ description#>\n", self.prefixString, paddedName, arg.name];
+        if ([[VVDocumenterSetting defaultSetting] alignArgumentComments]) {
+            name = [name stringByPaddingToLength:longestNameLength withString:@" " startingAtIndex:0];
+        }
+
+        [result appendFormat:@"%@@param %@ <#%@ description#>\n", self.prefixString, name, arg.name];
     }
     return result;
 }

--- a/VVDocumenter-Xcode/Setting/VVDSettingPanelWindowController.m
+++ b/VVDocumenter-Xcode/Setting/VVDSettingPanelWindowController.m
@@ -24,6 +24,7 @@
 @property (assign) IBOutlet NSButton *btnAddSinceToComment;
 @property (weak) IBOutlet NSButton *btnUseHeaderDoc;
 @property (weak) IBOutlet NSButton *btnBlankLinesBetweenSections;
+@property (weak) IBOutlet NSButton *btnAlightArgumentComments;
 @end
 
 @implementation VVDSettingPanelWindowController
@@ -49,6 +50,7 @@
     self.btnAddSinceToComment.state = (NSCellStateValue)[[VVDocumenterSetting defaultSetting] addSinceToComments];
     self.btnUseHeaderDoc.state = (NSCellStateValue)[[VVDocumenterSetting defaultSetting] useHeaderDoc];
     self.btnBlankLinesBetweenSections.state = (NSCellStateValue)[[VVDocumenterSetting defaultSetting] blankLinesBetweenSections];
+    self.btnAlightArgumentComments.state = (NSCellStateValue)[[VVDocumenterSetting defaultSetting] alignArgumentComments];
 
     if ([[VVDocumenterSetting defaultSetting] prefixWithStar]) {
         [self.mtxPrefixOptions selectCell:self.btnPrefixWithStar];
@@ -83,6 +85,7 @@
     [[VVDocumenterSetting defaultSetting] setAddSinceToComments:NO];
     [[VVDocumenterSetting defaultSetting] setUseHeaderDoc:NO];
     [[VVDocumenterSetting defaultSetting] setBlankLinesBetweenSections:YES];
+    [[VVDocumenterSetting defaultSetting] setAlignArgumentComments:YES];
 
     self.btnUseSpaces.state = NSOnState;
     [self updateUseSpace:self.btnUseSpaces.state];
@@ -93,6 +96,7 @@
     [self.tfTrigger setStringValue:VVDDefaultTriggerString];
     self.btnUseHeaderDoc.state = NSOffState;
     self.btnBlankLinesBetweenSections.state = NSOnState;
+    self.btnAlightArgumentComments.state = NSOnState;
 
     self.btnPrefixWithSlashes.enabled = YES;
 
@@ -166,4 +170,9 @@
 - (IBAction)blankLinesBetweenSections:(id)sender {
     [[VVDocumenterSetting defaultSetting] setBlankLinesBetweenSections:self.btnBlankLinesBetweenSections.state];
 }
+
+- (IBAction)alignArgumentComments:(id)sender {
+    [[VVDocumenterSetting defaultSetting] setAlignArgumentComments:self.btnAlightArgumentComments.state];
+}
+
 @end

--- a/VVDocumenter-Xcode/Setting/VVDSettingPanelWindowController.xib
+++ b/VVDocumenter-Xcode/Setting/VVDSettingPanelWindowController.xib
@@ -2,13 +2,13 @@
 <archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="8.00">
 	<data>
 		<int key="IBDocument.SystemTarget">1080</int>
-		<string key="IBDocument.SystemVersion">13B42</string>
-		<string key="IBDocument.InterfaceBuilderVersion">4514</string>
-		<string key="IBDocument.AppKitVersion">1265</string>
-		<string key="IBDocument.HIToolboxVersion">696.00</string>
+		<string key="IBDocument.SystemVersion">13C64</string>
+		<string key="IBDocument.InterfaceBuilderVersion">5056</string>
+		<string key="IBDocument.AppKitVersion">1265.19</string>
+		<string key="IBDocument.HIToolboxVersion">697.40</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin</string>
-			<string key="NS.object.0">4514</string>
+			<string key="NS.object.0">5056</string>
 		</object>
 		<array key="IBDocument.IntegratedClassDependencies">
 			<string>NSBox</string>
@@ -43,7 +43,7 @@
 			<object class="NSWindowTemplate" id="1005">
 				<int key="NSWindowStyleMask">3</int>
 				<int key="NSWindowBacking">2</int>
-				<string key="NSWindowRect">{{508, 391}, {460, 377}}</string>
+				<string key="NSWindowRect">{{508, 391}, {460, 407}}</string>
 				<int key="NSWTFlags">544735232</int>
 				<string key="NSWindowTitle">VVDocumenter Setting</string>
 				<string key="NSWindowClass">NSWindow</string>
@@ -56,7 +56,7 @@
 						<object class="NSButton" id="126835082">
 							<reference key="NSNextResponder" ref="1006"/>
 							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{67, 251}, {212, 35}}</string>
+							<string key="NSFrame">{{67, 281}, {212, 35}}</string>
 							<reference key="NSSuperview" ref="1006"/>
 							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="287259983"/>
@@ -92,7 +92,7 @@
 						<object class="NSTextField" id="837322658">
 							<reference key="NSNextResponder" ref="1006"/>
 							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{329, 260}, {60, 17}}</string>
+							<string key="NSFrame">{{329, 290}, {60, 17}}</string>
 							<reference key="NSSuperview" ref="1006"/>
 							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="899742890"/>
@@ -130,7 +130,7 @@
 						<object class="NSTextField" id="287259983">
 							<reference key="NSNextResponder" ref="1006"/>
 							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{279, 257}, {37, 22}}</string>
+							<string key="NSFrame">{{279, 287}, {37, 22}}</string>
 							<reference key="NSSuperview" ref="1006"/>
 							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="645523021"/>
@@ -190,7 +190,7 @@
 						<object class="NSTextField" id="972045408">
 							<reference key="NSNextResponder" ref="1006"/>
 							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{66, 338}, {107, 17}}</string>
+							<string key="NSFrame">{{66, 368}, {107, 17}}</string>
 							<reference key="NSSuperview" ref="1006"/>
 							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="79895721"/>
@@ -212,7 +212,7 @@
 						<object class="NSTextField" id="79895721">
 							<reference key="NSNextResponder" ref="1006"/>
 							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{279, 335}, {96, 22}}</string>
+							<string key="NSFrame">{{279, 365}, {96, 22}}</string>
 							<reference key="NSSuperview" ref="1006"/>
 							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="22971616"/>
@@ -235,7 +235,7 @@
 						<object class="NSTextField" id="22971616">
 							<reference key="NSNextResponder" ref="1006"/>
 							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{78, 292}, {295, 38}}</string>
+							<string key="NSFrame">{{78, 322}, {295, 38}}</string>
 							<reference key="NSSuperview" ref="1006"/>
 							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="126835082"/>
@@ -270,7 +270,7 @@
 						<object class="NSStepper" id="645523021">
 							<reference key="NSNextResponder" ref="1006"/>
 							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{312, 254}, {19, 27}}</string>
+							<string key="NSFrame">{{312, 284}, {19, 27}}</string>
 							<reference key="NSSuperview" ref="1006"/>
 							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="837322658"/>
@@ -290,7 +290,7 @@
 						<object class="NSButton" id="899742890">
 							<reference key="NSNextResponder" ref="1006"/>
 							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{67, 230}, {201, 18}}</string>
+							<string key="NSFrame">{{67, 260}, {201, 18}}</string>
 							<reference key="NSSuperview" ref="1006"/>
 							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="565957479"/>
@@ -317,7 +317,7 @@
 						<object class="NSButton" id="565957479">
 							<reference key="NSNextResponder" ref="1006"/>
 							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{67, 200}, {272, 18}}</string>
+							<string key="NSFrame">{{67, 230}, {272, 18}}</string>
 							<reference key="NSSuperview" ref="1006"/>
 							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="176216819"/>
@@ -344,10 +344,10 @@
 						<object class="NSButton" id="176216819">
 							<reference key="NSNextResponder" ref="1006"/>
 							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{67, 172}, {272, 18}}</string>
+							<string key="NSFrame">{{67, 202}, {272, 18}}</string>
 							<reference key="NSSuperview" ref="1006"/>
 							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView" ref="633252326"/>
+							<reference key="NSNextKeyView" ref="656911203"/>
 							<string key="NSReuseIdentifierKey">_NS:9</string>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSButtonCell" key="NSCell" id="185874400">
@@ -574,13 +574,40 @@ y7bMNcy1zTXNtc42zrbPN8+40DnQutE80b7SP9LB00TTxtRJ1MvVTtXR1lXW2Ndc1+DYZNjo2WzZ8dp2
 							<int key="NSTitlePosition">0</int>
 							<bool key="NSTransparent">NO</bool>
 						</object>
+						<object class="NSButton" id="656911203">
+							<reference key="NSNextResponder" ref="1006"/>
+							<int key="NSvFlags">268</int>
+							<string key="NSFrame">{{67, 170}, {272, 18}}</string>
+							<reference key="NSSuperview" ref="1006"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="633252326"/>
+							<string key="NSReuseIdentifierKey">_NS:9</string>
+							<bool key="NSEnabled">YES</bool>
+							<object class="NSButtonCell" key="NSCell" id="416924661">
+								<int key="NSCellFlags">-2080374784</int>
+								<int key="NSCellFlags2">268435456</int>
+								<string key="NSContents">Align argument comments</string>
+								<reference key="NSSupport" ref="45273652"/>
+								<string key="NSCellIdentifier">_NS:9</string>
+								<reference key="NSControlView" ref="656911203"/>
+								<int key="NSButtonFlags">1211912448</int>
+								<int key="NSButtonFlags2">2</int>
+								<reference key="NSNormalImage" ref="375391960"/>
+								<reference key="NSAlternateImage" ref="998663687"/>
+								<string key="NSAlternateContents"/>
+								<string key="NSKeyEquivalent"/>
+								<int key="NSPeriodicDelay">200</int>
+								<int key="NSPeriodicInterval">25</int>
+							</object>
+							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+						</object>
 					</array>
-					<string key="NSFrameSize">{460, 377}</string>
+					<string key="NSFrameSize">{460, 407}</string>
 					<reference key="NSSuperview"/>
 					<reference key="NSWindow"/>
 					<reference key="NSNextKeyView" ref="972045408"/>
 				</object>
-				<string key="NSScreenRect">{{0, 0}, {1920, 1058}}</string>
+				<string key="NSScreenRect">{{0, 0}, {2560, 1418}}</string>
 				<string key="NSMaxSize">{10000000000000, 10000000000000}</string>
 				<bool key="NSWindowIsRestorable">YES</bool>
 			</object>
@@ -749,6 +776,22 @@ y7bMNcy1zTXNtc42zrbPN8+40DnQutE80b7SP9LB00TTxtRJ1MvVTtXR1lXW2Ndc1+DYZNjo2WzZ8dp2
 					<string key="id">vCY-7n-Xqh</string>
 				</object>
 				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">alignArgumentComments:</string>
+						<reference key="source" ref="1001"/>
+						<reference key="destination" ref="656911203"/>
+					</object>
+					<string key="id">o62-1G-Tta</string>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBOutletConnection" key="connection">
+						<string key="label">btnAlightArgumentComments</string>
+						<reference key="source" ref="1001"/>
+						<reference key="destination" ref="656911203"/>
+					</object>
+					<string key="id">l9g-ge-CwY</string>
+				</object>
+				<object class="IBConnectionRecord">
 					<object class="IBOutletConnection" key="connection">
 						<string key="label">delegate</string>
 						<reference key="source" ref="1005"/>
@@ -808,6 +851,7 @@ y7bMNcy1zTXNtc42zrbPN8+40DnQutE80b7SP9LB00TTxtRJ1MvVTtXR1lXW2Ndc1+DYZNjo2WzZ8dp2
 							<reference ref="899742890"/>
 							<reference ref="565957479"/>
 							<reference ref="176216819"/>
+							<reference ref="656911203"/>
 						</array>
 						<reference key="parent" ref="1005"/>
 					</object>
@@ -991,6 +1035,19 @@ y7bMNcy1zTXNtc42zrbPN8+40DnQutE80b7SP9LB00TTxtRJ1MvVTtXR1lXW2Ndc1+DYZNjo2WzZ8dp2
 						<reference key="object" ref="185874400"/>
 						<reference key="parent" ref="176216819"/>
 					</object>
+					<object class="IBObjectRecord">
+						<string key="id">g3M-cK-u5v</string>
+						<reference key="object" ref="656911203"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="416924661"/>
+						</array>
+						<reference key="parent" ref="1006"/>
+					</object>
+					<object class="IBObjectRecord">
+						<string key="id">5tp-ni-55q</string>
+						<reference key="object" ref="416924661"/>
+						<reference key="parent" ref="656911203"/>
+					</object>
 				</array>
 			</object>
 			<dictionary class="NSMutableDictionary" key="flattenedProperties">
@@ -1018,6 +1075,7 @@ y7bMNcy1zTXNtc42zrbPN8+40DnQutE80b7SP9LB00TTxtRJ1MvVTtXR1lXW2Ndc1+DYZNjo2WzZ8dp2
 				<string key="31.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="54.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="55.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="5tp-ni-55q.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="6ax-Nw-Bq5.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="9.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="9MP-VX-rsW.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
@@ -1028,6 +1086,7 @@ y7bMNcy1zTXNtc42zrbPN8+40DnQutE80b7SP9LB00TTxtRJ1MvVTtXR1lXW2Ndc1+DYZNjo2WzZ8dp2
 				<string key="YoT-Nd-Bhd.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="bgb-aQ-BAa.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="eH9-9F-VR9.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="g3M-cK-u5v.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="mxJ-X3-ycD.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="vMT-lx-3Ep.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="wZv-eZ-WK7.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
@@ -1043,6 +1102,7 @@ y7bMNcy1zTXNtc42zrbPN8+40DnQutE80b7SP9LB00TTxtRJ1MvVTtXR1lXW2Ndc1+DYZNjo2WzZ8dp2
 					<string key="className">VVDSettingPanelWindowController</string>
 					<string key="superclassName">NSWindowController</string>
 					<dictionary class="NSMutableDictionary" key="actions">
+						<string key="alignArgumentComments:">id</string>
 						<string key="blankLinesBetweenSections:">id</string>
 						<string key="btnAddSinceToCommentsPressed:">id</string>
 						<string key="btnResetPressed:">id</string>
@@ -1052,6 +1112,10 @@ y7bMNcy1zTXNtc42zrbPN8+40DnQutE80b7SP9LB00TTxtRJ1MvVTtXR1lXW2Ndc1+DYZNjo2WzZ8dp2
 						<string key="useHeaderDoc:">id</string>
 					</dictionary>
 					<dictionary class="NSMutableDictionary" key="actionInfosByName">
+						<object class="IBActionInfo" key="alignArgumentComments:">
+							<string key="name">alignArgumentComments:</string>
+							<string key="candidateClassName">id</string>
+						</object>
 						<object class="IBActionInfo" key="blankLinesBetweenSections:">
 							<string key="name">blankLinesBetweenSections:</string>
 							<string key="candidateClassName">id</string>
@@ -1083,6 +1147,7 @@ y7bMNcy1zTXNtc42zrbPN8+40DnQutE80b7SP9LB00TTxtRJ1MvVTtXR1lXW2Ndc1+DYZNjo2WzZ8dp2
 					</dictionary>
 					<dictionary class="NSMutableDictionary" key="outlets">
 						<string key="btnAddSinceToComment">NSButton</string>
+						<string key="btnAlightArgumentComments">NSButton</string>
 						<string key="btnBlankLinesBetweenSections">NSButton</string>
 						<string key="btnPrefixWithSlashes">NSButtonCell</string>
 						<string key="btnPrefixWithStar">NSButtonCell</string>
@@ -1098,6 +1163,10 @@ y7bMNcy1zTXNtc42zrbPN8+40DnQutE80b7SP9LB00TTxtRJ1MvVTtXR1lXW2Ndc1+DYZNjo2WzZ8dp2
 					<dictionary class="NSMutableDictionary" key="toOneOutletInfosByName">
 						<object class="IBToOneOutletInfo" key="btnAddSinceToComment">
 							<string key="name">btnAddSinceToComment</string>
+							<string key="candidateClassName">NSButton</string>
+						</object>
+						<object class="IBToOneOutletInfo" key="btnAlightArgumentComments">
+							<string key="name">btnAlightArgumentComments</string>
 							<string key="candidateClassName">NSButton</string>
 						</object>
 						<object class="IBToOneOutletInfo" key="btnBlankLinesBetweenSections">

--- a/VVDocumenter-Xcode/Setting/VVDocumenterSetting.h
+++ b/VVDocumenter-Xcode/Setting/VVDocumenterSetting.h
@@ -22,5 +22,6 @@ extern NSString *const VVDDefaultTriggerString;
 @property BOOL addSinceToComments;
 @property BOOL useHeaderDoc;
 @property BOOL blankLinesBetweenSections;
+@property BOOL alignArgumentComments;
 @property (readonly) NSString *spacesString;
 @end

--- a/VVDocumenter-Xcode/Setting/VVDocumenterSetting.m
+++ b/VVDocumenter-Xcode/Setting/VVDocumenterSetting.m
@@ -19,6 +19,7 @@ NSString *const kVVDPrefixWithSlashes = @"com.onevcat.VVDocumenter.prefixWithSla
 NSString *const kVVDAddSinceToComments = @"com.onevcat.VVDocumenter.addSinceToComments";
 NSString *const kVVDUserHeaderDoc = @"com.onevcat.VVDocumenter.useHeaderDoc";
 NSString *const kVVDNoBlankLinesBetweenFields = @"com.onevcat.VVDocumenter.noBlankLinesBetweenFields";
+NSString *const kVVDNoArgumentPadding = @"com.onevcat.VVDocumenter.noArgumentPadding";
 @implementation VVDocumenterSetting
 
 + (VVDocumenterSetting *)defaultSetting
@@ -147,6 +148,16 @@ NSString *const kVVDNoBlankLinesBetweenFields = @"com.onevcat.VVDocumenter.noBla
 -(void) setBlankLinesBetweenSections:(BOOL)blankLinesBetweenFields
 {
     [[NSUserDefaults standardUserDefaults] setBool:!blankLinesBetweenFields forKey:kVVDNoBlankLinesBetweenFields];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+}
+
+-(BOOL) alignArgumentComments
+{
+    return ![[NSUserDefaults standardUserDefaults] boolForKey:kVVDNoArgumentPadding];
+}
+-(void) setAlignArgumentComments:(BOOL)alignArgumentComments
+{
+    [[NSUserDefaults standardUserDefaults] setBool:!alignArgumentComments forKey:kVVDNoArgumentPadding];
     [[NSUserDefaults standardUserDefaults] synchronize];
 }
 


### PR DESCRIPTION
I couldn’t find an option to avoid aligning argument comments (a common style which I also use), so I made one. What do you think?

This is the default.

```
@param argument           <#argument description#>
@param reallyLongArugment <#reallyLongArugment description#>
```

This is the new option.

```
@param argument <#argument description#>
@param reallyLongArugment <#reallyLongArugment description#>
```
