### PR TITLE
fixed bug #83

### DIFF
--- a/VVDocumenter-Xcode/OCCategory/NSString+VVSyntax/NSString+VVSyntax.m
+++ b/VVDocumenter-Xcode/OCCategory/NSString+VVSyntax/NSString+VVSyntax.m
@@ -81,7 +81,9 @@
 
 -(BOOL) vv_isSwiftProperty
 {
-    return [self vv_matchesPatternRegexPattern:@"^\\s*(.*?)(\\s*let|var\\s*)\\s+"];
+    // `let`/`var` can be in swift func, but `(` appear before `let`/`var` only
+    // happens when `private(set)` or `internal(set)` is used
+    return [self vv_matchesPatternRegexPattern:@"^\\s*([^(]*?)(((\\s*let|var\\s*)\\s+)|(\\(\\s*set\\s*\\)))"];
 }
 
 @end

--- a/VVDocumenterTests/DocumenterTests/VVMethodTestsCode.plist
+++ b/VVDocumenterTests/DocumenterTests/VVMethodTestsCode.plist
@@ -429,6 +429,21 @@ SIAlertViewBackgroundStyleSolid,
 	</array>
 	<key>vv_isSwiftFunction</key>
 	<array>
+        <dict>
+            <key>source</key>
+            <string>func testParasType(var a: Int, let b: Int, inout c: Int, d: Int) {</string>
+            <key>uniform</key>
+            <string>func testParasType(var a: Int, let b: Int, inout c: Int, d: Int){</string>
+            <key>result</key>
+            <string>/**
+ &lt;#Description#&gt;
+
+ :param: a &lt;#a description#&gt;
+ :param: b &lt;#b description#&gt;
+ :param: c &lt;#c description#&gt;
+ :param: d &lt;#d description#&gt;
+ */</string>
+        </dict>
 		<dict>
 			<key>source</key>
 			<string>func sayHello(personName: String) -&gt; String  {</string>

--- a/VVDocumenterTests/VVTestHelper.m
+++ b/VVDocumenterTests/VVTestHelper.m
@@ -69,7 +69,8 @@ static NSArray *_typeStrings;
 
     NSArray *swiftFunctions = @[@"func sayHello(personName: String) -> String  {",
                                 @"func halfOpenRangeLength(start: Int, end: Int) -> Int\n  {",
-                                @"func sayHelloWorld() ->String"];
+                                @"func sayHelloWorld() ->String",
+                                @"func testParamsType(var a: Int) {"];
     
     /*
     //Now there is no difference between Objective-C (C) struct and Swift struct. Ignore this.
@@ -134,6 +135,7 @@ static NSArray *_typeStrings;
     NSArray *swiftFunctions = @[@"func sayHello(personName: String)-> String  {",
                                 @"func halfOpenRangeLength(start: Int, end: Int)-> Int {",
                                 @"func sayHelloWorld()->String",
+                                @"func testParamsType(var a: Int){",
                                 @"init(style: Style, gearing: Gearing, handlebar: Handlebar, frameSize centimeters: Int) {"];
     
     /*


### PR DESCRIPTION
In check swift function:

```swift
return ![self vv_isObjCMethod] && ![self vv_isSwiftProperty] && [self vv_matchesPatternRegexPattern:@"^\\s*(.*\\s+)?(func\\s+)|(init|deinit)"];
```

will do swift property check first in which only `var`/`let` is used, so swift function check will fail when `var`/`let` type of params is used.

The fix make some change in swift property check:

```swift
return [self vv_matchesPatternRegexPattern:@"^\\s*([^(]*?)(((\\s*let|var\\s*)\\s+)|(\\(\\s*set\\s*\\)))"];
```

because in property declaration, `(` appearing before `let`/`var` only happens when `private(set)` or `internal(set)` is used