### PR TITLE
Adding auto fill for version numbers with @since

### DIFF
--- a/VVDocumenter-Xcode/Commenter/VVBaseCommenter.m
+++ b/VVDocumenter-Xcode/Commenter/VVBaseCommenter.m
@@ -144,10 +144,39 @@
     VVProject *project = [VVProject projectForKeyWindow];
     
     if (!self.forSwift && [[VVDocumenterSetting defaultSetting] addSinceToComments]) {
-        if (project.projectVersion && project.projectVersion.length>0) {
-            return [NSString stringWithFormat:@"%@%@@since <#%@#>\n", self.emptyLine, self.prefixString,project.projectVersion];
-        }else{
-         return [NSString stringWithFormat:@"%@%@@since <#version number#>\n", self.emptyLine, self.prefixString];
+
+        VVDSinceOption sinceOption = [[VVDocumenterSetting defaultSetting] sinceOption];
+
+        switch (sinceOption) {
+            case VVDSinceOptionPlaceholder: {
+
+                return [NSString stringWithFormat:@"%@%@@since <#version number#>\n", self.emptyLine, self.prefixString];
+                break;
+            }
+            case VVDSinceOptionProjectVersion: {
+
+                if (project.projectVersion && project.projectVersion.length>0) {
+
+                    return [NSString stringWithFormat:@"%@%@@since <#%@#>\n", self.emptyLine, self.prefixString,project.projectVersion];
+                }else{
+                    // Fall back onto default placeholder if no project version can be obtained.
+                    return [NSString stringWithFormat:@"%@%@@since <#version number#>\n", self.emptyLine, self.prefixString];
+                }
+
+                break;
+            }
+            case VVDSinceOptionSpecificVersion: {
+
+                NSString *version = [[VVDocumenterSetting defaultSetting] sinceVersion];
+                if (version && version.length>0) {
+
+                    return [NSString stringWithFormat:@"%@%@@since <#%@#>\n", self.emptyLine, self.prefixString, version];
+                }else{
+                    // Fall back onto default placeholder if no version can be obtained.
+                    return [NSString stringWithFormat:@"%@%@@since <#version number#>\n", self.emptyLine, self.prefixString];
+                }
+                break;
+            }
         }
     } else {
         return @"";

--- a/VVDocumenter-Xcode/Setting/VVDSettingPanelWindowController.m
+++ b/VVDocumenter-Xcode/Setting/VVDSettingPanelWindowController.m
@@ -17,11 +17,12 @@
 
 @property (weak) IBOutlet NSStepper *stepperCount;
 
+@property (weak) IBOutlet NSMatrix *mtxSinceOptions;
 @property (weak) IBOutlet NSMatrix *mtxPrefixOptions;
 @property (weak) IBOutlet NSButtonCell *btnPrefixWithWhitespace;
 @property (weak) IBOutlet NSButtonCell *btnPrefixWithStar;
 @property (weak) IBOutlet NSButtonCell *btnPrefixWithSlashes;
-@property (assign) IBOutlet NSButton *btnAddSinceToComment;
+@property (weak) IBOutlet NSButton *btnAddSinceToComment;
 @property (weak) IBOutlet NSButton *btnBriefDescription;
 @property (weak) IBOutlet NSButton *btnUseHeaderDoc;
 @property (weak) IBOutlet NSButton *btnBlankLinesBetweenSections;
@@ -30,6 +31,7 @@
 @property (weak) IBOutlet NSButton *btnUseDateInformation;
 @property (weak) IBOutlet NSTextField *tfAuthoInformation;
 @property (weak) IBOutlet NSTextField *tfDateInformaitonFormat;
+@property (weak) IBOutlet NSTextField *tfSinceVersion;
 
 @end
 
@@ -54,6 +56,11 @@
     self.btnUseSpaces.state = (NSCellStateValue)[[VVDocumenterSetting defaultSetting] useSpaces];
 
     self.btnAddSinceToComment.state = (NSCellStateValue)[[VVDocumenterSetting defaultSetting] addSinceToComments];
+    self.mtxSinceOptions.enabled = [[VVDocumenterSetting defaultSetting] addSinceToComments];
+    [self.mtxSinceOptions selectCellAtRow:(NSInteger)[[VVDocumenterSetting defaultSetting] sinceOption] column:0];
+    self.tfSinceVersion.enabled = [[VVDocumenterSetting defaultSetting] addSinceToComments];
+    self.tfSinceVersion.stringValue = [[VVDocumenterSetting defaultSetting] sinceVersion];
+
     self.btnBriefDescription.state = (NSCellStateValue)[[VVDocumenterSetting defaultSetting] briefDescription];
     self.btnUseHeaderDoc.state = (NSCellStateValue)[[VVDocumenterSetting defaultSetting] useHeaderDoc];
     self.btnBlankLinesBetweenSections.state = (NSCellStateValue)[[VVDocumenterSetting defaultSetting] blankLinesBetweenSections];
@@ -82,6 +89,7 @@
     self.tfTrigger.delegate = self;
     self.tfDateInformaitonFormat.delegate = self;
     self.tfAuthoInformation.delegate = self;
+    self.tfSinceVersion.delegate = self;
 }
 
 - (IBAction)stepperPressed:(id)sender {
@@ -96,6 +104,7 @@
     [[VVDocumenterSetting defaultSetting] setPrefixWithStar:YES];
     [[VVDocumenterSetting defaultSetting] setPrefixWithSlashes:NO];
     [[VVDocumenterSetting defaultSetting] setAddSinceToComments:NO];
+    [[VVDocumenterSetting defaultSetting] setSinceVersion:@""];
     [[VVDocumenterSetting defaultSetting] setBriefDescription:NO];
     [[VVDocumenterSetting defaultSetting] setUseHeaderDoc:NO];
     [[VVDocumenterSetting defaultSetting] setBlankLinesBetweenSections:YES];
@@ -111,6 +120,8 @@
     self.btnPrefixWithStar.state = NSOnState;
     self.btnPrefixWithSlashes.state = NSOffState;
     self.btnAddSinceToComment.state = NSOffState;
+    self.tfSinceVersion.enabled = NO;
+    self.mtxSinceOptions.enabled = NO;
     self.btnBriefDescription.state = NSOffState;
     [self.tfTrigger setStringValue:VVDDefaultTriggerString];
     self.btnUseHeaderDoc.state = NSOffState;
@@ -127,6 +138,11 @@
 
 }
 
+- (IBAction)mtxSinceOptionPressed:(id)sender {
+    VVDSinceOption option = self.mtxSinceOptions.selectedRow;
+    [[VVDocumenterSetting defaultSetting] setSinceOption:option];
+}
+
 - (IBAction)btnUseSpacesPressed:(id)sender {
     [[VVDocumenterSetting defaultSetting] setUseSpaces:self.btnUseSpaces.state];
     [self updateUseSpace:self.btnUseSpaces.state];
@@ -140,7 +156,10 @@
 }
 
 - (IBAction)btnAddSinceToCommentsPressed:(id)sender {
-    [[VVDocumenterSetting defaultSetting] setAddSinceToComments:self.btnAddSinceToComment.state];
+    BOOL enableSince = self.btnAddSinceToComment.state;
+    [[VVDocumenterSetting defaultSetting] setAddSinceToComments:enableSince];
+    self.tfSinceVersion.enabled = enableSince;
+    self.mtxSinceOptions.enabled = enableSince;
 }
 
 - (IBAction)btnBriefDescriptionPressed:(id)sender {
@@ -179,6 +198,9 @@
     }
     if([notification object] == self.tfDateInformaitonFormat) {
         [[VVDocumenterSetting defaultSetting] setDateInformationFormat:self.tfDateInformaitonFormat.stringValue];
+    }
+    if ([notification object] == self.tfSinceVersion) {
+        [[VVDocumenterSetting defaultSetting] setSinceVersion:self.tfSinceVersion.stringValue];
     }
 }
 

--- a/VVDocumenter-Xcode/Setting/VVDSettingPanelWindowController.xib
+++ b/VVDocumenter-Xcode/Setting/VVDSettingPanelWindowController.xib
@@ -2,13 +2,13 @@
 <archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="8.00">
 	<data>
 		<int key="IBDocument.SystemTarget">1080</int>
-		<string key="IBDocument.SystemVersion">14A361c</string>
-		<string key="IBDocument.InterfaceBuilderVersion">6245</string>
-		<string key="IBDocument.AppKitVersion">1339</string>
+		<string key="IBDocument.SystemVersion">14A389</string>
+		<string key="IBDocument.InterfaceBuilderVersion">7531</string>
+		<string key="IBDocument.AppKitVersion">1343.14</string>
 		<string key="IBDocument.HIToolboxVersion">755.00</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin</string>
-			<string key="NS.object.0">6245</string>
+			<string key="NS.object.0">7531</string>
 		</object>
 		<array key="IBDocument.IntegratedClassDependencies">
 			<string>NSBox</string>
@@ -43,7 +43,7 @@
 			<object class="NSWindowTemplate" id="1005">
 				<int key="NSWindowStyleMask">3</int>
 				<int key="NSWindowBacking">2</int>
-				<string key="NSWindowRect">{{508, 391}, {463, 519}}</string>
+				<string key="NSWindowRect">{{20, 40}, {463, 586}}</string>
 				<int key="NSWTFlags">544735232</int>
 				<string key="NSWindowTitle">VVDocumenter Setting</string>
 				<string key="NSWindowClass">NSWindow</string>
@@ -56,7 +56,7 @@
 						<object class="NSButton" id="126835082">
 							<reference key="NSNextResponder" ref="1006"/>
 							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{67, 393}, {212, 35}}</string>
+							<string key="NSFrame">{{67, 460}, {212, 35}}</string>
 							<reference key="NSSuperview" ref="1006"/>
 							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="287259983"/>
@@ -92,7 +92,7 @@
 						<object class="NSTextField" id="837322658">
 							<reference key="NSNextResponder" ref="1006"/>
 							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{329, 402}, {60, 17}}</string>
+							<string key="NSFrame">{{329, 469}, {60, 17}}</string>
 							<reference key="NSSuperview" ref="1006"/>
 							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="899742890"/>
@@ -130,7 +130,7 @@
 						<object class="NSTextField" id="287259983">
 							<reference key="NSNextResponder" ref="1006"/>
 							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{279, 399}, {37, 22}}</string>
+							<string key="NSFrame">{{279, 466}, {37, 22}}</string>
 							<reference key="NSSuperview" ref="1006"/>
 							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="645523021"/>
@@ -169,7 +169,6 @@
 							<string key="NSFrame">{{11, 13}, {113, 32}}</string>
 							<reference key="NSSuperview" ref="1006"/>
 							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView"/>
 							<string key="NSReuseIdentifierKey">_NS:9</string>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSButtonCell" key="NSCell" id="238216401">
@@ -191,7 +190,7 @@
 						<object class="NSTextField" id="972045408">
 							<reference key="NSNextResponder" ref="1006"/>
 							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{66, 480}, {107, 17}}</string>
+							<string key="NSFrame">{{66, 547}, {107, 17}}</string>
 							<reference key="NSSuperview" ref="1006"/>
 							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="79895721"/>
@@ -213,7 +212,7 @@
 						<object class="NSTextField" id="79895721">
 							<reference key="NSNextResponder" ref="1006"/>
 							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{279, 477}, {96, 22}}</string>
+							<string key="NSFrame">{{279, 544}, {96, 22}}</string>
 							<reference key="NSSuperview" ref="1006"/>
 							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="22971616"/>
@@ -259,7 +258,7 @@
 						<object class="NSTextField" id="22971616">
 							<reference key="NSNextResponder" ref="1006"/>
 							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{78, 434}, {295, 38}}</string>
+							<string key="NSFrame">{{78, 501}, {295, 38}}</string>
 							<reference key="NSSuperview" ref="1006"/>
 							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="126835082"/>
@@ -272,7 +271,7 @@
 								<object class="NSFont" key="NSSupport">
 									<bool key="IBIsSystemFont">YES</bool>
 									<double key="NSSize">12</double>
-									<int key="NSfFlags">4883</int>
+									<int key="NSfFlags">787</int>
 								</object>
 								<string key="NSCellIdentifier">_NS:1535</string>
 								<reference key="NSControlView" ref="22971616"/>
@@ -294,7 +293,7 @@
 						<object class="NSStepper" id="645523021">
 							<reference key="NSNextResponder" ref="1006"/>
 							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{312, 396}, {19, 27}}</string>
+							<string key="NSFrame">{{312, 463}, {19, 27}}</string>
 							<reference key="NSSuperview" ref="1006"/>
 							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="837322658"/>
@@ -314,10 +313,10 @@
 						<object class="NSButton" id="899742890">
 							<reference key="NSNextResponder" ref="1006"/>
 							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{67, 372}, {201, 18}}</string>
+							<string key="NSFrame">{{67, 439}, {201, 18}}</string>
 							<reference key="NSSuperview" ref="1006"/>
 							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView" ref="288934219"/>
+							<reference key="NSNextKeyView" ref="927116466"/>
 							<string key="NSReuseIdentifierKey">_NS:9</string>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSButtonCell" key="NSCell" id="716256895">
@@ -548,7 +547,7 @@ y7bMNcy1zTXNtc42zrbPN8+40DnQutE80b7SP9LB00TTxtRJ1MvVTtXR1lXW2Ndc1+DYZNjo2WzZ8dp2
 												</object>
 											</array>
 										</array>
-										<object class="NSColor" key="NSColor">
+										<object class="NSColor" key="NSColor" id="601329775">
 											<int key="NSColorSpace">3</int>
 											<bytes key="NSWhite">MCAwAA</bytes>
 										</object>
@@ -775,13 +774,206 @@ y7bMNcy1zTXNtc42zrbPN8+40DnQutE80b7SP9LB00TTxtRJ1MvVTtXR1lXW2Ndc1+DYZNjo2WzZ8dp2
 							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 							<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
 						</object>
+						<object class="NSMatrix" id="927116466">
+							<reference key="NSNextResponder" ref="1006"/>
+							<int key="NSvFlags">268</int>
+							<string key="NSFrame">{{85, 366}, {167, 67}}</string>
+							<reference key="NSSuperview" ref="1006"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="836021866"/>
+							<string key="NSReuseIdentifierKey">_NS:9</string>
+							<bool key="NSEnabled">YES</bool>
+							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+							<int key="NSNumRows">3</int>
+							<int key="NSNumCols">1</int>
+							<array class="NSMutableArray" key="NSCells">
+								<object class="NSButtonCell" id="424422323">
+									<int key="NSCellFlags">-2080374784</int>
+									<int key="NSCellFlags2">0</int>
+									<string key="NSContents">Use default placeholder</string>
+									<reference key="NSSupport" ref="45273652"/>
+									<reference key="NSControlView" ref="927116466"/>
+									<int key="NSTag">1</int>
+									<int key="NSButtonFlags">1211912448</int>
+									<int key="NSButtonFlags2">0</int>
+									<reference key="NSAlternateImage" ref="712014434"/>
+									<string key="NSAlternateContents"/>
+									<string key="NSKeyEquivalent"/>
+									<int key="NSPeriodicDelay">200</int>
+									<int key="NSPeriodicInterval">25</int>
+								</object>
+								<object class="NSButtonCell" id="828032942">
+									<int key="NSCellFlags">67108864</int>
+									<int key="NSCellFlags2">0</int>
+									<string key="NSContents">Use project version</string>
+									<reference key="NSSupport" ref="45273652"/>
+									<reference key="NSControlView" ref="927116466"/>
+									<int key="NSButtonFlags">1211912448</int>
+									<int key="NSButtonFlags2">0</int>
+									<object class="NSImage" key="NSNormalImage" id="1042056847">
+										<int key="NSImageFlags">549453824</int>
+										<string key="NSSize">{18, 18}</string>
+										<array class="NSMutableArray" key="NSReps">
+											<array>
+												<integer value="0"/>
+												<object class="NSBitmapImageRep">
+													<object class="NSData" key="NSTIFFRepresentation">
+														<bytes key="NS.bytes">TU0AKgAABRgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAMAAAADAAAAAwAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAADwRERGLJycnySsrK/A1NTXw
+IyMjyRwcHIsJCQk8AAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFFRUVdVBQUOCoqKj/
+29vb//n5+f/6+vr/2tra/6qqqv9UVFTgHx8fdQAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUZGRl5
+dXV198PDw//8/Pz////////////////////////////U1NT/fHx89yUlJXkAAAAFAAAAAAAAAAAAAAAA
+AAAAAxEREUZqamrmtbW1/+3t7f/+/v7//v7+//7+/v/9/f3//f39//39/f/39/f/xMTE/3d3d+YZGRlG
+AAAAAwAAAAAAAAAAAAAACkJCQqGtra3/xsbG/+vr6//y8vL/9fX1//X19f/z8/P/9fX1//Ly8v/u7u7/
+0tLS/6+vr/9KSkqhAAAACgAAAAAAAAAAAAAAF3h4eN2/v7//z8/P/93d3f/q6ur/7+/v/+/v7//w8PD/
+7e3t/+3t7f/i4uL/zs7O/8XFxf98fHzdAAAAFwAAAAAAAAADAAAAJKSkpPjOzs7/2dnZ/+Dg4P/i4uL/
+5eXl/+bm5v/n5+f/5eXl/+Li4v/e3t7/2tra/9DQ0P+srKz4AAAAJAAAAAMAAAADAAAALrCwsPrW1tb/
+3t7e/+Tk5P/p6en/6+vr/+zs7P/p6en/6+vr/+fn5//k5OT/4ODg/9nZ2f+zs7P6AAAALgAAAAMAAAAD
+AAAALp2dnezg4OD/5eXl/+rq6v/u7u7/8PDw//Dw8P/x8fH/8PDw/+7u7v/q6ur/5ubm/+Hh4f+ZmZns
+AAAALgAAAAMAAAADAAAAJG5ubs/l5eX/6enp/+/v7//y8vL/9vb2//r6+v/5+fn/9/f3//b29v/x8fH/
+6+vr/+Tk5P9ra2vPAAAAJAAAAAMAAAAAAAAAFy4uLpPCwsL67Ozs//Pz8//5+fn//v7+//7+/v/+/v7/
+/v7+//v7+//19fX/8PDw/8LCwvosLCyTAAAAFwAAAAAAAAAAAAAACgAAAENfX1/S5OTk/vn5+f/+/v7/
+///////////////////////////8/Pz/5ubm/l9fX9IAAABDAAAACgAAAAAAAAAAAAAAAwAAABcAAABl
+YmJi3NLS0v3////////////////////////////////V1dX9ZGRk3AAAAGUAAAAXAAAAAwAAAAAAAAAA
+AAAAAAAAAAUAAAAfAAAAZTMzM8KAgIDwv7+//O3t7f/t7e3/v7+//ICAgPAzMzPCAAAAZQAAAB8AAAAF
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFAAAAFwAAAEMAAAB3AAAAnwAAALMAAACzAAAAnwAAAHcAAABD
+AAAAFwAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAoAAAAXAAAAJAAAAC4AAAAu
+AAAAJAAAABcAAAAKAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAwAAAAMAAAADAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADgEAAAMAAAABABIAAAEB
+AAMAAAABABIAAAECAAMAAAAEAAAFxgEDAAMAAAABAAEAAAEGAAMAAAABAAIAAAERAAQAAAABAAAACAES
+AAMAAAABAAEAAAEVAAMAAAABAAQAAAEWAAMAAAABABIAAAEXAAQAAAABAAAFEAEcAAMAAAABAAEAAAFS
+AAMAAAABAAEAAAFTAAMAAAAEAAAFzodzAAcAAAxIAAAF1gAAAAAACAAIAAgACAABAAEAAQABAAAMSExp
+bm8CEAAAbW50clJHQiBYWVogB84AAgAJAAYAMQAAYWNzcE1TRlQAAAAASUVDIHNSR0IAAAAAAAAAAAAA
+AAAAAPbWAAEAAAAA0y1IUCAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAARY3BydAAAAVAAAAAzZGVzYwAAAYQAAABsd3RwdAAAAfAAAAAUYmtwdAAAAgQAAAAUclhZWgAA
+AhgAAAAUZ1hZWgAAAiwAAAAUYlhZWgAAAkAAAAAUZG1uZAAAAlQAAABwZG1kZAAAAsQAAACIdnVlZAAA
+A0wAAACGdmlldwAAA9QAAAAkbHVtaQAAA/gAAAAUbWVhcwAABAwAAAAkdGVjaAAABDAAAAAMclRSQwAA
+BDwAAAgMZ1RSQwAABDwAAAgMYlRSQwAABDwAAAgMdGV4dAAAAABDb3B5cmlnaHQgKGMpIDE5OTggSGV3
+bGV0dC1QYWNrYXJkIENvbXBhbnkAAGRlc2MAAAAAAAAAEnNSR0IgSUVDNjE5NjYtMi4xAAAAAAAAAAAA
+AAASc1JHQiBJRUM2MTk2Ni0yLjEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAFhZWiAAAAAAAADzUQABAAAAARbMWFlaIAAAAAAAAAAAAAAAAAAAAABYWVogAAAAAAAA
+b6IAADj1AAADkFhZWiAAAAAAAABimQAAt4UAABjaWFlaIAAAAAAAACSgAAAPhAAAts9kZXNjAAAAAAAA
+ABZJRUMgaHR0cDovL3d3dy5pZWMuY2gAAAAAAAAAAAAAABZJRUMgaHR0cDovL3d3dy5pZWMuY2gAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZGVzYwAAAAAAAAAuSUVDIDYx
+OTY2LTIuMSBEZWZhdWx0IFJHQiBjb2xvdXIgc3BhY2UgLSBzUkdCAAAAAAAAAAAAAAAuSUVDIDYxOTY2
+LTIuMSBEZWZhdWx0IFJHQiBjb2xvdXIgc3BhY2UgLSBzUkdCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGRl
+c2MAAAAAAAAALFJlZmVyZW5jZSBWaWV3aW5nIENvbmRpdGlvbiBpbiBJRUM2MTk2Ni0yLjEAAAAAAAAA
+AAAAACxSZWZlcmVuY2UgVmlld2luZyBDb25kaXRpb24gaW4gSUVDNjE5NjYtMi4xAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAB2aWV3AAAAAAATpP4AFF8uABDPFAAD7cwABBMLAANcngAAAAFYWVogAAAAAABM
+CVYAUAAAAFcf521lYXMAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAKPAAAAAnNpZyAAAAAAQ1JUIGN1
+cnYAAAAAAAAEAAAAAAUACgAPABQAGQAeACMAKAAtADIANwA7AEAARQBKAE8AVABZAF4AYwBoAG0AcgB3
+AHwAgQCGAIsAkACVAJoAnwCkAKkArgCyALcAvADBAMYAywDQANUA2wDgAOUA6wDwAPYA+wEBAQcBDQET
+ARkBHwElASsBMgE4AT4BRQFMAVIBWQFgAWcBbgF1AXwBgwGLAZIBmgGhAakBsQG5AcEByQHRAdkB4QHp
+AfIB+gIDAgwCFAIdAiYCLwI4AkECSwJUAl0CZwJxAnoChAKOApgCogKsArYCwQLLAtUC4ALrAvUDAAML
+AxYDIQMtAzgDQwNPA1oDZgNyA34DigOWA6IDrgO6A8cD0wPgA+wD+QQGBBMEIAQtBDsESARVBGMEcQR+
+BIwEmgSoBLYExATTBOEE8AT+BQ0FHAUrBToFSQVYBWcFdwWGBZYFpgW1BcUF1QXlBfYGBgYWBicGNwZI
+BlkGagZ7BowGnQavBsAG0QbjBvUHBwcZBysHPQdPB2EHdAeGB5kHrAe/B9IH5Qf4CAsIHwgyCEYIWghu
+CIIIlgiqCL4I0gjnCPsJEAklCToJTwlkCXkJjwmkCboJzwnlCfsKEQonCj0KVApqCoEKmAquCsUK3Arz
+CwsLIgs5C1ELaQuAC5gLsAvIC+EL+QwSDCoMQwxcDHUMjgynDMAM2QzzDQ0NJg1ADVoNdA2ODakNww3e
+DfgOEw4uDkkOZA5/DpsOtg7SDu4PCQ8lD0EPXg96D5YPsw/PD+wQCRAmEEMQYRB+EJsQuRDXEPURExEx
+EU8RbRGMEaoRyRHoEgcSJhJFEmQShBKjEsMS4xMDEyMTQxNjE4MTpBPFE+UUBhQnFEkUahSLFK0UzhTw
+FRIVNBVWFXgVmxW9FeAWAxYmFkkWbBaPFrIW1hb6Fx0XQRdlF4kXrhfSF/cYGxhAGGUYihivGNUY+hkg
+GUUZaxmRGbcZ3RoEGioaURp3Gp4axRrsGxQbOxtjG4obshvaHAIcKhxSHHscoxzMHPUdHh1HHXAdmR3D
+HeweFh5AHmoelB6+HukfEx8+H2kflB+/H+ogFSBBIGwgmCDEIPAhHCFIIXUhoSHOIfsiJyJVIoIiryLd
+IwojOCNmI5QjwiPwJB8kTSR8JKsk2iUJJTglaCWXJccl9yYnJlcmhya3JugnGCdJJ3onqyfcKA0oPyhx
+KKIo1CkGKTgpaymdKdAqAio1KmgqmyrPKwIrNitpK50r0SwFLDksbiyiLNctDC1BLXYtqy3hLhYuTC6C
+Lrcu7i8kL1ovkS/HL/4wNTBsMKQw2zESMUoxgjG6MfIyKjJjMpsy1DMNM0YzfzO4M/E0KzRlNJ402DUT
+NU01hzXCNf02NzZyNq426TckN2A3nDfXOBQ4UDiMOMg5BTlCOX85vDn5OjY6dDqyOu87LTtrO6o76Dwn
+PGU8pDzjPSI9YT2hPeA+ID5gPqA+4D8hP2E/oj/iQCNAZECmQOdBKUFqQaxB7kIwQnJCtUL3QzpDfUPA
+RANER0SKRM5FEkVVRZpF3kYiRmdGq0bwRzVHe0fASAVIS0iRSNdJHUljSalJ8Eo3Sn1KxEsMS1NLmkvi
+TCpMcky6TQJNSk2TTdxOJU5uTrdPAE9JT5NP3VAnUHFQu1EGUVBRm1HmUjFSfFLHUxNTX1OqU/ZUQlSP
+VNtVKFV1VcJWD1ZcVqlW91dEV5JX4FgvWH1Yy1kaWWlZuFoHWlZaplr1W0VblVvlXDVchlzWXSddeF3J
+XhpebF69Xw9fYV+zYAVgV2CqYPxhT2GiYfViSWKcYvBjQ2OXY+tkQGSUZOllPWWSZedmPWaSZuhnPWeT
+Z+loP2iWaOxpQ2maafFqSGqfavdrT2una/9sV2yvbQhtYG25bhJua27Ebx5veG/RcCtwhnDgcTpxlXHw
+cktypnMBc11zuHQUdHB0zHUodYV14XY+dpt2+HdWd7N4EXhueMx5KnmJeed6RnqlewR7Y3vCfCF8gXzh
+fUF9oX4BfmJ+wn8jf4R/5YBHgKiBCoFrgc2CMIKSgvSDV4O6hB2EgITjhUeFq4YOhnKG14c7h5+IBIhp
+iM6JM4mZif6KZIrKizCLlov8jGOMyo0xjZiN/45mjs6PNo+ekAaQbpDWkT+RqJIRknqS45NNk7aUIJSK
+lPSVX5XJljSWn5cKl3WX4JhMmLiZJJmQmfyaaJrVm0Kbr5wcnImc951kndKeQJ6unx2fi5/6oGmg2KFH
+obaiJqKWowajdqPmpFakx6U4pammGqaLpv2nbqfgqFKoxKk3qamqHKqPqwKrdavprFys0K1ErbiuLa6h
+rxavi7AAsHWw6rFgsdayS7LCszizrrQltJy1E7WKtgG2ebbwt2i34LhZuNG5SrnCuju6tbsuu6e8Ibyb
+vRW9j74KvoS+/796v/XAcMDswWfB48JfwtvDWMPUxFHEzsVLxcjGRsbDx0HHv8g9yLzJOsm5yjjKt8s2
+y7bMNcy1zTXNtc42zrbPN8+40DnQutE80b7SP9LB00TTxtRJ1MvVTtXR1lXW2Ndc1+DYZNjo2WzZ8dp2
+2vvbgNwF3IrdEN2W3hzeot8p36/gNuC94UThzOJT4tvjY+Pr5HPk/OWE5g3mlucf56noMui86Ubp0Opb
+6uXrcOv77IbtEe2c7ijutO9A78zwWPDl8XLx//KM8xnzp/Q09ML1UPXe9m32+/eK+Bn4qPk4+cf6V/rn
++3f8B/yY/Sn9uv5L/tz/bf//A</bytes>
+													</object>
+												</object>
+											</array>
+										</array>
+										<reference key="NSColor" ref="601329775"/>
+									</object>
+									<reference key="NSAlternateImage" ref="712014434"/>
+									<int key="NSPeriodicDelay">400</int>
+									<int key="NSPeriodicInterval">75</int>
+								</object>
+								<object class="NSButtonCell" id="658262876">
+									<int key="NSCellFlags">67108864</int>
+									<int key="NSCellFlags2">0</int>
+									<string key="NSContents">Use specific version</string>
+									<reference key="NSSupport" ref="45273652"/>
+									<reference key="NSControlView" ref="927116466"/>
+									<int key="NSButtonFlags">1211912448</int>
+									<int key="NSButtonFlags2">0</int>
+									<reference key="NSNormalImage" ref="1042056847"/>
+									<reference key="NSAlternateImage" ref="712014434"/>
+									<int key="NSPeriodicDelay">400</int>
+									<int key="NSPeriodicInterval">75</int>
+								</object>
+							</array>
+							<string key="NSCellSize">{169, 18}</string>
+							<string key="NSIntercellSpacing">{4, 2}</string>
+							<int key="NSMatrixFlags">1151868928</int>
+							<string key="NSCellClass">NSActionCell</string>
+							<object class="NSButtonCell" key="NSProtoCell" id="263636098">
+								<int key="NSCellFlags">67108864</int>
+								<int key="NSCellFlags2">0</int>
+								<string key="NSContents">Radio</string>
+								<reference key="NSSupport" ref="45273652"/>
+								<int key="NSButtonFlags">1211912448</int>
+								<int key="NSButtonFlags2">0</int>
+								<reference key="NSNormalImage" ref="1042056847"/>
+								<reference key="NSAlternateImage" ref="712014434"/>
+								<int key="NSPeriodicDelay">400</int>
+								<int key="NSPeriodicInterval">75</int>
+							</object>
+							<int key="NSSelectedRow">1</int>
+							<reference key="NSSelectedCell" ref="828032942"/>
+							<reference key="NSBackgroundColor" ref="274064682"/>
+							<reference key="NSCellBackgroundColor" ref="124282544"/>
+							<reference key="NSFont" ref="45273652"/>
+							<bool key="NSAutorecalculatesCellSize">YES</bool>
+						</object>
+						<object class="NSTextField" id="836021866">
+							<reference key="NSNextResponder" ref="1006"/>
+							<int key="NSvFlags">268</int>
+							<string key="NSFrame">{{279, 373}, {96, 22}}</string>
+							<reference key="NSSuperview" ref="1006"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="288934219"/>
+							<string key="NSReuseIdentifierKey">_NS:9</string>
+							<bool key="NSEnabled">YES</bool>
+							<object class="NSTextFieldCell" key="NSCell" id="20958187">
+								<int key="NSCellFlags">-1804599231</int>
+								<int key="NSCellFlags2">272630784</int>
+								<string key="NSContents"/>
+								<reference key="NSSupport" ref="45273652"/>
+								<string key="NSPlaceholderString">Version</string>
+								<string key="NSCellIdentifier">_NS:9</string>
+								<reference key="NSControlView" ref="836021866"/>
+								<bool key="NSDrawsBackground">YES</bool>
+								<reference key="NSBackgroundColor" ref="128694125"/>
+								<reference key="NSTextColor" ref="497281150"/>
+							</object>
+							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+							<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
+						</object>
 					</array>
-					<string key="NSFrameSize">{463, 519}</string>
+					<string key="NSFrameSize">{463, 586}</string>
 					<reference key="NSSuperview"/>
 					<reference key="NSWindow"/>
 					<reference key="NSNextKeyView" ref="972045408"/>
 				</object>
-				<string key="NSScreenRect">{{0, 0}, {1680, 1027}}</string>
+				<string key="NSScreenRect">{{0, 0}, {2560, 1417}}</string>
 				<string key="NSMaxSize">{10000000000000, 10000000000000}</string>
 				<bool key="NSWindowIsRestorable">YES</bool>
 			</object>
@@ -1031,6 +1223,54 @@ y7bMNcy1zTXNtc42zrbPN8+40DnQutE80b7SP9LB00TTxtRJ1MvVTtXR1lXW2Ndc1+DYZNjo2WzZ8dp2
 				</object>
 				<object class="IBConnectionRecord">
 					<object class="IBOutletConnection" key="connection">
+						<string key="label">tfSinceVersion</string>
+						<reference key="source" ref="1001"/>
+						<reference key="destination" ref="836021866"/>
+					</object>
+					<string key="id">Xj0-Zg-bCx</string>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBOutletConnection" key="connection">
+						<string key="label">mtxSinceOptions</string>
+						<reference key="source" ref="1001"/>
+						<reference key="destination" ref="927116466"/>
+					</object>
+					<string key="id">uSS-BQ-O3Z</string>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">mtxSinceOptionPressed:</string>
+						<reference key="source" ref="1001"/>
+						<reference key="destination" ref="927116466"/>
+					</object>
+					<string key="id">fFz-uM-7g0</string>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBOutletConnection" key="connection">
+						<string key="label">btnDefaultPlaceholder</string>
+						<reference key="source" ref="1001"/>
+						<reference key="destination" ref="424422323"/>
+					</object>
+					<string key="id">TeO-Jj-IsJ</string>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBOutletConnection" key="connection">
+						<string key="label">btnProjectVersion</string>
+						<reference key="source" ref="1001"/>
+						<reference key="destination" ref="828032942"/>
+					</object>
+					<string key="id">OIF-HV-I6g</string>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBOutletConnection" key="connection">
+						<string key="label">btnSpecificVersion</string>
+						<reference key="source" ref="1001"/>
+						<reference key="destination" ref="658262876"/>
+					</object>
+					<string key="id">21F-j3-SGO</string>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBOutletConnection" key="connection">
 						<string key="label">delegate</string>
 						<reference key="source" ref="1005"/>
 						<reference key="destination" ref="1001"/>
@@ -1097,6 +1337,8 @@ y7bMNcy1zTXNtc42zrbPN8+40DnQutE80b7SP9LB00TTxtRJ1MvVTtXR1lXW2Ndc1+DYZNjo2WzZ8dp2
 							<reference ref="329267316"/>
 							<reference ref="906605780"/>
 							<reference ref="192925133"/>
+							<reference ref="927116466"/>
+							<reference ref="836021866"/>
 						</array>
 						<reference key="parent" ref="1005"/>
 					</object>
@@ -1384,6 +1626,50 @@ y7bMNcy1zTXNtc42zrbPN8+40DnQutE80b7SP9LB00TTxtRJ1MvVTtXR1lXW2Ndc1+DYZNjo2WzZ8dp2
 						<reference key="object" ref="358125470"/>
 						<reference key="parent" ref="192925133"/>
 					</object>
+					<object class="IBObjectRecord">
+						<string key="id">F04-TF-nUJ</string>
+						<reference key="object" ref="927116466"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="424422323"/>
+							<reference ref="263636098"/>
+							<reference ref="828032942"/>
+							<reference ref="658262876"/>
+						</array>
+						<reference key="parent" ref="1006"/>
+					</object>
+					<object class="IBObjectRecord">
+						<string key="id">3Uj-1c-BzU</string>
+						<reference key="object" ref="424422323"/>
+						<reference key="parent" ref="927116466"/>
+					</object>
+					<object class="IBObjectRecord">
+						<string key="id">SMy-aZ-Tel</string>
+						<reference key="object" ref="263636098"/>
+						<reference key="parent" ref="927116466"/>
+					</object>
+					<object class="IBObjectRecord">
+						<string key="id">lQp-YM-3hX</string>
+						<reference key="object" ref="836021866"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="20958187"/>
+						</array>
+						<reference key="parent" ref="1006"/>
+					</object>
+					<object class="IBObjectRecord">
+						<string key="id">OAk-cF-UEV</string>
+						<reference key="object" ref="20958187"/>
+						<reference key="parent" ref="836021866"/>
+					</object>
+					<object class="IBObjectRecord">
+						<string key="id">pSZ-Vj-hkT</string>
+						<reference key="object" ref="828032942"/>
+						<reference key="parent" ref="927116466"/>
+					</object>
+					<object class="IBObjectRecord">
+						<string key="id">PbN-ts-AYz</string>
+						<reference key="object" ref="658262876"/>
+						<reference key="parent" ref="927116466"/>
+					</object>
 				</array>
 			</object>
 			<dictionary class="NSMutableDictionary" key="flattenedProperties">
@@ -1392,13 +1678,14 @@ y7bMNcy1zTXNtc42zrbPN8+40DnQutE80b7SP9LB00TTxtRJ1MvVTtXR1lXW2Ndc1+DYZNjo2WzZ8dp2
 				<string key="-3.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<boolean value="YES" key="1.IBNSWindowAutoPositionCentersHorizontal"/>
 				<boolean value="YES" key="1.IBNSWindowAutoPositionCentersVertical"/>
-				<string key="1.IBPersistedLastKnownCanvasPosition">{424.5, 462.5}</string>
+				<string key="1.IBPersistedLastKnownCanvasPosition">{424.5, 496}</string>
 				<string key="1.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="1.IBWindowTemplateEditedContentRect">{{357, 418}, {480, 270}}</string>
 				<boolean value="YES" key="1.NSWindowTemplate.visibleAtLaunch"/>
 				<string key="10.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="16.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="17.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<reference key="2.IBNSViewMetadataGestureRecognizers" ref="0"/>
 				<string key="2.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="22.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="23.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
@@ -1410,6 +1697,7 @@ y7bMNcy1zTXNtc42zrbPN8+40DnQutE80b7SP9LB00TTxtRJ1MvVTtXR1lXW2Ndc1+DYZNjo2WzZ8dp2
 				<string key="29.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="30.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="31.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="3Uj-1c-BzU.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="3w5-ev-VuS.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="54.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="55.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
@@ -1420,11 +1708,15 @@ y7bMNcy1zTXNtc42zrbPN8+40DnQutE80b7SP9LB00TTxtRJ1MvVTtXR1lXW2Ndc1+DYZNjo2WzZ8dp2
 				<string key="9MP-VX-rsW.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="C3y-LS-75k.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="ERW-1g-i3X.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="F04-TF-nUJ.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="Haw-5R-IXR.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="IVu-o3-DBW.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="Krc-dg-Cog.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="L0g-BX-Fh0.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="OAk-cF-UEV.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="PbN-ts-AYz.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="Qwl-tK-TKG.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="SMy-aZ-Tel.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="To6-Zf-QbE.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="YoT-Nd-Bhd.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="b6P-6I-DiH.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
@@ -1432,7 +1724,9 @@ y7bMNcy1zTXNtc42zrbPN8+40DnQutE80b7SP9LB00TTxtRJ1MvVTtXR1lXW2Ndc1+DYZNjo2WzZ8dp2
 				<string key="eH9-9F-VR9.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="g3M-cK-u5v.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="gfy-6Z-t8f.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="lQp-YM-3hX.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="mxJ-X3-ycD.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="pSZ-Vj-hkT.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="s2i-JB-wgP.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="vMT-lx-3Ep.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="wKY-lg-WfF.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
@@ -1469,6 +1763,7 @@ y7bMNcy1zTXNtc42zrbPN8+40DnQutE80b7SP9LB00TTxtRJ1MvVTtXR1lXW2Ndc1+DYZNjo2WzZ8dp2
 						<string key="btnUseDateInformationPressed:">id</string>
 						<string key="btnUseSpacesPressed:">id</string>
 						<string key="mtxPrefixSettingPressed:">id</string>
+						<string key="mtxSinceOptionPressed:">id</string>
 						<string key="stepperPressed:">id</string>
 						<string key="useHeaderDoc:">id</string>
 					</dictionary>
@@ -1509,6 +1804,10 @@ y7bMNcy1zTXNtc42zrbPN8+40DnQutE80b7SP9LB00TTxtRJ1MvVTtXR1lXW2Ndc1+DYZNjo2WzZ8dp2
 							<string key="name">mtxPrefixSettingPressed:</string>
 							<string key="candidateClassName">id</string>
 						</object>
+						<object class="IBActionInfo" key="mtxSinceOptionPressed:">
+							<string key="name">mtxSinceOptionPressed:</string>
+							<string key="candidateClassName">id</string>
+						</object>
 						<object class="IBActionInfo" key="stepperPressed:">
 							<string key="name">stepperPressed:</string>
 							<string key="candidateClassName">id</string>
@@ -1531,9 +1830,11 @@ y7bMNcy1zTXNtc42zrbPN8+40DnQutE80b7SP9LB00TTxtRJ1MvVTtXR1lXW2Ndc1+DYZNjo2WzZ8dp2
 						<string key="btnUseHeaderDoc">NSButton</string>
 						<string key="btnUseSpaces">NSButton</string>
 						<string key="mtxPrefixOptions">NSMatrix</string>
+						<string key="mtxSinceOptions">NSMatrix</string>
 						<string key="stepperCount">NSStepper</string>
 						<string key="tfAuthoInformation">NSTextField</string>
 						<string key="tfDateInformaitonFormat">NSTextField</string>
+						<string key="tfSinceVersion">NSTextField</string>
 						<string key="tfSpaceCount">NSTextField</string>
 						<string key="tfSpaceLabel">NSTextField</string>
 						<string key="tfTrigger">NSTextField</string>
@@ -1587,6 +1888,10 @@ y7bMNcy1zTXNtc42zrbPN8+40DnQutE80b7SP9LB00TTxtRJ1MvVTtXR1lXW2Ndc1+DYZNjo2WzZ8dp2
 							<string key="name">mtxPrefixOptions</string>
 							<string key="candidateClassName">NSMatrix</string>
 						</object>
+						<object class="IBToOneOutletInfo" key="mtxSinceOptions">
+							<string key="name">mtxSinceOptions</string>
+							<string key="candidateClassName">NSMatrix</string>
+						</object>
 						<object class="IBToOneOutletInfo" key="stepperCount">
 							<string key="name">stepperCount</string>
 							<string key="candidateClassName">NSStepper</string>
@@ -1597,6 +1902,10 @@ y7bMNcy1zTXNtc42zrbPN8+40DnQutE80b7SP9LB00TTxtRJ1MvVTtXR1lXW2Ndc1+DYZNjo2WzZ8dp2
 						</object>
 						<object class="IBToOneOutletInfo" key="tfDateInformaitonFormat">
 							<string key="name">tfDateInformaitonFormat</string>
+							<string key="candidateClassName">NSTextField</string>
+						</object>
+						<object class="IBToOneOutletInfo" key="tfSinceVersion">
+							<string key="name">tfSinceVersion</string>
 							<string key="candidateClassName">NSTextField</string>
 						</object>
 						<object class="IBToOneOutletInfo" key="tfSpaceCount">
@@ -1779,10 +2088,6 @@ y7bMNcy1zTXNtc42zrbPN8+40DnQutE80b7SP9LB00TTxtRJ1MvVTtXR1lXW2Ndc1+DYZNjo2WzZ8dp2
 		<int key="IBDocument.localizationMode">0</int>
 		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaFramework</string>
 		<bool key="IBDocument.previouslyAttemptedUpgradeToXcode5">YES</bool>
-		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDependencyDefaults">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.macosx</string>
-			<real value="1080" key="NS.object.0"/>
-		</object>
 		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDevelopmentDependencies">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.InterfaceBuilder3</string>
 			<integer value="4600" key="NS.object.0"/>

--- a/VVDocumenter-Xcode/Setting/VVDocumenterSetting.h
+++ b/VVDocumenter-Xcode/Setting/VVDocumenterSetting.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-typedef NS_ENUM(NSUInteger, VVDSinceOption) {
+typedef NS_ENUM(NSInteger, VVDSinceOption) {
     VVDSinceOptionPlaceholder,
     VVDSinceOptionProjectVersion,
     VVDSinceOptionSpecificVersion,

--- a/VVDocumenter-Xcode/Setting/VVDocumenterSetting.h
+++ b/VVDocumenter-Xcode/Setting/VVDocumenterSetting.h
@@ -8,6 +8,12 @@
 
 #import <Foundation/Foundation.h>
 
+typedef NS_ENUM(NSUInteger, VVDSinceOption) {
+    VVDSinceOptionPlaceholder,
+    VVDSinceOptionProjectVersion,
+    VVDSinceOptionSpecificVersion,
+};
+
 extern NSString *const VVDDefaultTriggerString;
 extern NSString *const VVDDefaultAuthorString;
 extern NSString *const VVDDefaultDateInfomationFormat;
@@ -20,9 +26,11 @@ extern NSString *const VVDDefaultDateInfomationFormat;
 @property BOOL useSpaces;
 @property NSInteger spaceCount;
 @property NSString *triggerString;
+@property VVDSinceOption sinceOption;
 @property BOOL prefixWithStar;
 @property BOOL prefixWithSlashes;
 @property BOOL addSinceToComments;
+@property NSString *sinceVersion;
 @property BOOL briefDescription;
 @property BOOL useHeaderDoc;
 @property BOOL blankLinesBetweenSections;

--- a/VVDocumenter-Xcode/Setting/VVDocumenterSetting.m
+++ b/VVDocumenter-Xcode/Setting/VVDocumenterSetting.m
@@ -20,6 +20,8 @@ NSString *const kVVDTriggerString = @"com.onevcat.VVDocumenter.triggerString";
 NSString *const kVVDPrefixWithStar = @"com.onevcat.VVDocumenter.prefixWithStar";
 NSString *const kVVDPrefixWithSlashes = @"com.onevcat.VVDocumenter.prefixWithSlashes";
 NSString *const kVVDAddSinceToComments = @"com.onevcat.VVDocumenter.addSinceToComments";
+NSString *const kVVDSinceVersion = @"com.onevcat.VVDocumenter.sinceVersion";
+NSString *const kVVDSinceOption = @"com.onevcat.VVDocumenter.sinceOption";
 NSString *const kVVDBriefDescription = @"com.onevcat.VVDocumenter.briefDescription";
 NSString *const kVVDUserHeaderDoc = @"com.onevcat.VVDocumenter.useHeaderDoc";
 NSString *const kVVDNoBlankLinesBetweenFields = @"com.onevcat.VVDocumenter.noBlankLinesBetweenFields";
@@ -120,6 +122,19 @@ NSString *const kVVDDateInformationFormat = @"com.onevcat.VVDocumenter.dateInfor
     [[NSUserDefaults standardUserDefaults] synchronize];
 }
 
+-(VVDSinceOption) sinceOption
+{
+    NSNumber *option = [[NSUserDefaults standardUserDefaults] objectForKey:kVVDSinceOption];
+    return (VVDSinceOption)option.unsignedIntegerValue;
+}
+
+- (void)setSinceOption:(VVDSinceOption)sinceOption
+{
+    NSNumber *option = @(sinceOption);
+    [[NSUserDefaults standardUserDefaults] setObject:option forKey:kVVDSinceOption];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+}
+
 -(BOOL) prefixWithStar
 {
     return [[NSUserDefaults standardUserDefaults] boolForKey:kVVDPrefixWithStar];
@@ -150,6 +165,17 @@ NSString *const kVVDDateInformationFormat = @"com.onevcat.VVDocumenter.dateInfor
 -(void) setAddSinceToComments:(BOOL)add
 {
     [[NSUserDefaults standardUserDefaults] setBool:add forKey:kVVDAddSinceToComments];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+}
+
+- (NSString *)sinceVersion
+{
+    return [[NSUserDefaults standardUserDefaults] objectForKey:kVVDSinceVersion];
+}
+
+- (void)setSinceVersion:(NSString *)sinceVersion
+{
+    [[NSUserDefaults standardUserDefaults] setObject:sinceVersion forKey:kVVDSinceVersion];
     [[NSUserDefaults standardUserDefaults] synchronize];
 }
 

--- a/VVDocumenter-Xcode/Setting/VVDocumenterSetting.m
+++ b/VVDocumenter-Xcode/Setting/VVDocumenterSetting.m
@@ -124,14 +124,12 @@ NSString *const kVVDDateInformationFormat = @"com.onevcat.VVDocumenter.dateInfor
 
 -(VVDSinceOption) sinceOption
 {
-    NSNumber *option = [[NSUserDefaults standardUserDefaults] objectForKey:kVVDSinceOption];
-    return (VVDSinceOption)option.unsignedIntegerValue;
+    return (VVDSinceOption)[[NSUserDefaults standardUserDefaults] integerForKey:kVVDSinceOption];
 }
 
 - (void)setSinceOption:(VVDSinceOption)sinceOption
 {
-    NSNumber *option = @(sinceOption);
-    [[NSUserDefaults standardUserDefaults] setObject:option forKey:kVVDSinceOption];
+    [[NSUserDefaults standardUserDefaults] setInteger:sinceOption forKey:kVVDSinceOption];
     [[NSUserDefaults standardUserDefaults] synchronize];
 }
 

--- a/VVDocumenter-Xcode/Setting/VVDocumenterSetting.m
+++ b/VVDocumenter-Xcode/Setting/VVDocumenterSetting.m
@@ -170,7 +170,13 @@ NSString *const kVVDDateInformationFormat = @"com.onevcat.VVDocumenter.dateInfor
 
 - (NSString *)sinceVersion
 {
-    return [[NSUserDefaults standardUserDefaults] objectForKey:kVVDSinceVersion];
+    NSString *sinceVersion = [[NSUserDefaults standardUserDefaults] objectForKey:kVVDSinceVersion];
+
+    if ( ! sinceVersion ) {
+        sinceVersion = @"";
+    }
+
+    return sinceVersion;
 }
 
 - (void)setSinceVersion:(NSString *)sinceVersion


### PR DESCRIPTION
## Description

I thought it would be nice to have a version number filled in automatically when documenting, so I added some options in the settings panel. 

## Changes 

- Added some options in the setting panel to select a completion format for the @since annotation. 
   * Using the current default <#version number#> placeholder.
   * Using the project version number.
   * Using a specific version number supplied in the settings panel. 
![image](http://i.imgur.com/vQwnq5J.gif)
- In the case of the last two options, if a version number can't be obtained the comment will default back to the default placeholder.
![image](http://i.imgur.com/1y8qrE3.gif)