### PR TITLE
Keyboard layout refactor

### DIFF
--- a/VVDocumenter-Xcode/Setting/VVDocumenterSetting.h
+++ b/VVDocumenter-Xcode/Setting/VVDocumenterSetting.h
@@ -39,8 +39,7 @@ extern NSString *const VVDDefaultDateInfomationFormat;
 @interface VVDocumenterSetting : NSObject
 + (VVDocumenterSetting *)defaultSetting;
 
-@property (readonly) BOOL useDvorakLayout;
-@property (readonly) BOOL useWorkmanLayout;
+@property (readonly) NSInteger keyVCode;
 @property BOOL useSpaces;
 @property NSInteger spaceCount;
 @property NSString *triggerString;

--- a/VVDocumenter-Xcode/Setting/VVDocumenterSetting.m
+++ b/VVDocumenter-Xcode/Setting/VVDocumenterSetting.m
@@ -75,30 +75,21 @@ NSString *const kVVDDateInformationFormat = @"com.onevcat.VVDocumenter.dateInfor
     [[NSUserDefaults standardUserDefaults] synchronize];
 }
 
--(BOOL) useDvorakLayout
+-(NSInteger) keyVCode
 {
     TISInputSourceRef inputSource = TISCopyCurrentKeyboardLayoutInputSource();
     NSString *layoutID = (__bridge NSString *)TISGetInputSourceProperty(inputSource, kTISPropertyInputSourceID);
     CFRelease(inputSource);
-    
-    if ([layoutID rangeOfString:@"Dvorak" options:NSCaseInsensitiveSearch].location != NSNotFound && ![layoutID containsString:@"QWERTYCMD"]) {
-        return YES;
-    } else {
-        return NO;
-    }
-}
 
--(BOOL) useWorkmanLayout
-{
-    TISInputSourceRef inputSource = TISCopyCurrentKeyboardLayoutInputSource();
-    NSString *layoutID = (__bridge NSString *)TISGetInputSourceProperty(inputSource, kTISPropertyInputSourceID);
-    CFRelease(inputSource);
+    if ([layoutID rangeOfString:@"Dvorak" options:NSCaseInsensitiveSearch].location != NSNotFound && ![layoutID containsString:@"QWERTYCMD"]) {
+        return kVK_ANSI_Period;
+    }
 
     if ([layoutID rangeOfString:@"Workman" options:NSCaseInsensitiveSearch].location != NSNotFound && ![layoutID containsString:@"QWERTYCMD"]) {
-        return YES;
-    } else {
-        return NO;
+        return kVK_ANSI_B;
     }
+
+    return kVK_ANSI_V;
 }
 
 

--- a/VVDocumenter-Xcode/Setting/VVDocumenterSetting.m
+++ b/VVDocumenter-Xcode/Setting/VVDocumenterSetting.m
@@ -81,11 +81,23 @@ NSString *const kVVDDateInformationFormat = @"com.onevcat.VVDocumenter.dateInfor
     NSString *layoutID = (__bridge NSString *)TISGetInputSourceProperty(inputSource, kTISPropertyInputSourceID);
     CFRelease(inputSource);
 
-    if ([layoutID rangeOfString:@"Dvorak" options:NSCaseInsensitiveSearch].location != NSNotFound && ![layoutID containsString:@"QWERTYCMD"]) {
+    // Possible dvorak layout SourceIDs:
+    //    com.apple.keylayout.Dvorak (System Qwerty)
+    // But exclude:
+    //    com.apple.keylayout.DVORAK-QWERTYCMD (System Qwerty ⌘)
+    //    org.unknown.keylayout.DvorakImproved-Qwerty⌘ (http://www.macupdate.com/app/mac/24137/dvorak-improved-keyboard-layout)
+    if ([layoutID localizedCaseInsensitiveContainsString:@"dvorak"] && ![layoutID localizedCaseInsensitiveContainsString: @"qwerty"]) {
         return kVK_ANSI_Period;
     }
 
-    if ([layoutID rangeOfString:@"Workman" options:NSCaseInsensitiveSearch].location != NSNotFound && ![layoutID containsString:@"QWERTYCMD"]) {
+    // Possible workman layout SourceIDs (https://github.com/ojbucao/Workman):
+    //    org.sil.ukelele.keyboardlayout.workman.workman
+    //    org.sil.ukelele.keyboardlayout.workman.workmanextended
+    //    org.sil.ukelele.keyboardlayout.workman.workman-io
+    //    org.sil.ukelele.keyboardlayout.workman.workman-p
+    //    org.sil.ukelele.keyboardlayout.workman.workman-pextended
+    //    org.sil.ukelele.keyboardlayout.workman.workman-dead
+    if ([layoutID localizedCaseInsensitiveContainsString:@"workman"]) {
         return kVK_ANSI_B;
     }
 

--- a/VVDocumenter-Xcode/VVDocumenterManager.m
+++ b/VVDocumenter-Xcode/VVDocumenterManager.m
@@ -185,12 +185,8 @@
                 //Cmd+delete Delete current line
                 [kes sendKeyCode:kVK_Delete withModifierCommand:YES alt:NO shift:NO control:NO];
                 //if (shouldReplace) [textView setSelectedRange:resultToDocument.range];
-                //Cmd+V, paste (If it is Dvorak layout, use '.', which is corresponding the key 'V' in a QWERTY layout)
-                NSInteger kKeyVCode = [[VVDocumenterSetting defaultSetting] useDvorakLayout] ? kVK_ANSI_Period : kVK_ANSI_V;
-                if ([[VVDocumenterSetting defaultSetting] useWorkmanLayout]) {
-                    kKeyVCode = kVK_ANSI_B;
-                }
-                
+                //Cmd+V, paste (which key to actually use is based on the current keyboard layout)
+                NSInteger kKeyVCode = [[VVDocumenterSetting defaultSetting] keyVCode];
                 [kes sendKeyCode:kKeyVCode withModifierCommand:YES alt:NO shift:NO control:NO];
                 
                 //The key down is just a defined finish signal by me. When we receive this key, we know operation above is finished.


### PR DESCRIPTION
- Refactors the keyboard layout -> key shortcut stuff into something that's at least slightly more extensible going forward (RE: #150). It might make more sense to move the mappings themselves to a `plist` or something, but this is at least a step in the right direction for right now.
- Adds support for a [weird variant](http://www.macupdate.com/app/mac/24137/dvorak-improved-keyboard-layout) of the `Dvorak - Qwerty ⌘` layout that's floating around the intertubes.
- Adds documentation for the `TISPropertyInputSourceID`s that we're currently matching against to make it easier to sanity check future additions.