### PR TITLE
Fix Swift parameters

### DIFF
--- a/VVDocumenter-Xcode/Commenter/VVBaseCommenter.m
+++ b/VVDocumenter-Xcode/Commenter/VVBaseCommenter.m
@@ -172,6 +172,11 @@
                 }
             }
         }
+        else {
+            if (self.forSwiftEnum || self.forSwift) {
+                name = [name stringByAppendingString:@":"];
+            }
+        }
 
         NSString *indentString = useSpace ? @" " : @"\t";
         if (self.forSwiftEnum) {


### PR DESCRIPTION
Swift parameter markup has a colon (“:”) after the parameter name. If
the alignArgumentComments setting is true, then the colon will be
present, but if it is false it won’t. The fix is simply to append a
colon after the name for Swift comments.

Fixes issue #217 